### PR TITLE
fix: Hide inline popover on click outside only

### DIFF
--- a/packages/lit/src/components/inline-popover/controller.ts
+++ b/packages/lit/src/components/inline-popover/controller.ts
@@ -27,9 +27,14 @@ export class InlinePopoverController implements ReactiveController {
     const handleMouseDown = () => {
       this.mouseHovering = true
     }
-    const handleMouseUp = () => {
+    const handleMouseUp = (e: MouseEvent) => {
+      const matched = e.composedPath().find((_el) => {
+        const el = _el as HTMLElement
+        return el.tagName?.toLowerCase() === 'prosekit-inline-popover'
+      })
+
       this.mouseHovering = false
-      this.update()
+      if (!matched) this.update()
     }
 
     document.addEventListener('mousedown', handleMouseDown)

--- a/playground/example.meta.ts
+++ b/playground/example.meta.ts
@@ -592,6 +592,10 @@ export const exampleMeta = {
         {
           "path": "extension.ts",
           "hidden": false
+        },
+        {
+          "path": "inline-menu.vue",
+          "hidden": false
         }
       ]
     },

--- a/playground/example.meta.yaml
+++ b/playground/example.meta.yaml
@@ -307,6 +307,8 @@ examples:
         hidden: false
       - path: extension.ts
         hidden: false
+      - path: inline-menu.vue
+        hidden: false
   - name: vue-list
     framework: vue
     story: list

--- a/playground/examples/vue-link/editor.vue
+++ b/playground/examples/vue-link/editor.vue
@@ -5,6 +5,7 @@ import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
 import { ref, watchPostEffect } from 'vue'
 import { defineExtension } from './extension'
+import InlineMenu from './inline-menu.vue'
 
 const defaultHTML = `
   <p><a href="https://www.example.com">www.example.com</a></p>
@@ -19,6 +20,7 @@ watchPostEffect(() => editor.mount(editorRef.value))
   <ProseKit :editor="editor">
     <div class="EDITOR_VIEWPORT">
       <div ref="editorRef" class="EDITOR_CONTENT"></div>
+      <InlineMenu />
     </div>
   </ProseKit>
 </template>

--- a/playground/examples/vue-link/inline-menu.vue
+++ b/playground/examples/vue-link/inline-menu.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { useEditor } from 'prosekit/vue'
+import type { EditorExtension } from './extension'
+import { InlinePopover } from 'prosekit/vue/inline-popover'
+
+import { ref } from 'vue'
+
+const editor = useEditor<EditorExtension>({ update: true })
+
+const linkUrl = ref('')
+const linkInput = ref<HTMLElement | null>(null)
+
+function addLink() {
+  const href = linkUrl.value.trim()
+
+  if (href.length) {
+    editor.value.commands.addLink({ href })
+  } else {
+    editor.value.commands.toggleLink({ href: '' })
+  }
+  linkUrl.value = ''
+}
+</script>
+
+<template>
+  <InlinePopover class="INLINE_MENU" :editor="editor">
+    <form class="flex gap-2" @submit.prevent="addLink">
+      <input ref="linkInput" v-model="linkUrl" class="outline-none px-1 w-full" type="text" placeholder="https://" />
+      <button type="submit">
+        Add link
+      </button>
+      <button v-if="editor.marks.link.isActive()" @click="addLink()" @mousedown.prevent>
+        Remove link
+      </button>
+    </form>
+    <div @mousedown.prevent>@mousedown.prevent</div>
+    <div>Click here close the popup</div>
+  </InlinePopover>
+</template>

--- a/playground/examples/vue-link/inline-menu.vue
+++ b/playground/examples/vue-link/inline-menu.vue
@@ -25,11 +25,19 @@ function addLink() {
 <template>
   <InlinePopover class="INLINE_MENU" :editor="editor">
     <form class="flex gap-2" @submit.prevent="addLink">
-      <input ref="linkInput" v-model="linkUrl" class="outline-none px-1 w-full" type="text" placeholder="https://" />
-      <button type="submit">
-        Add link
-      </button>
-      <button v-if="editor.marks.link.isActive()" @click="addLink()" @mousedown.prevent>
+      <input
+        ref="linkInput"
+        v-model="linkUrl"
+        class="outline-none px-1 w-full"
+        type="text"
+        placeholder="https://"
+      />
+      <button type="submit">Add link</button>
+      <button
+        v-if="editor.marks.link.isActive()"
+        @click="addLink()"
+        @mousedown.prevent
+      >
         Remove link
       </button>
     </form>

--- a/website/examples/link.md
+++ b/website/examples/link.md
@@ -12,6 +12,7 @@ import { ExamplePreview } from '@/components/example-preview/example-preview.tsx
 
 <<< @/../playground/examples/vue-link/editor.vue
 <<< @/../playground/examples/vue-link/extension.ts
+<<< @/../playground/examples/vue-link/inline-menu.vue
 
 :::
 


### PR DESCRIPTION
The first commit add the inline popover in the link example. You can see that we can't select the input because the popup disappear on mouseup event.
Also, we can't select the input if we add `@mousedown.prevent` on it.

So, to prevent this, I added some code to check if the click event performs inside the popup.
But I'm not sure if it's the good way to fix this behaviour. And maybe we can add an option for this...