### PR TITLE
fix(lit): hide the inline popover when the selection collapse

### DIFF
--- a/.changeset/heavy-mugs-smoke.md
+++ b/.changeset/heavy-mugs-smoke.md
@@ -1,5 +1,6 @@
 ---
-"@prosekit/lit": patch
+'prosekit': patch
+'@prosekit/lit': patch
 ---
 
 Fix an issue where the inline popover won't disappear when the text selection collapse.

--- a/.changeset/heavy-mugs-smoke.md
+++ b/.changeset/heavy-mugs-smoke.md
@@ -3,4 +3,4 @@
 '@prosekit/lit': patch
 ---
 
-Fix an issue where the inline popover won't disappear when the text selection collapse.
+Fix an issue where the inline popover won't disappear when the text selection collapse after you have clicked the inline popover.

--- a/.changeset/heavy-mugs-smoke.md
+++ b/.changeset/heavy-mugs-smoke.md
@@ -1,0 +1,5 @@
+---
+"@prosekit/lit": patch
+---
+
+Fix an issue where the inline popover won't disappear when the text selection collapse.

--- a/packages/lit/src/components/inline-popover/use-inline-popover.ts
+++ b/packages/lit/src/components/inline-popover/use-inline-popover.ts
@@ -3,32 +3,30 @@ import type { LitElement } from 'lit'
 
 import { useEditorFocusChangeEvent } from '../../controllers/use-editor-focus-event'
 import { useEditorUpdateEvent } from '../../controllers/use-editor-update-event'
-import { usePointerDownEvent } from '../../controllers/use-pointer-down-event'
 import type { WithEditor } from '../../types/with-editor'
 
 import { getVirtualSelectionElement } from './helpers'
 
+/**
+ * @internal
+ */
 export function useInlinePopover(
   host: WithEditor<LitElement>,
   onReferenceChange: (reference: ReferenceElement | undefined) => void,
 ) {
-  let interacting = false
   let reference: ReferenceElement | undefined
+  let editorFocused = false
 
-  usePointerDownEvent(host, () => {
-    interacting = true
-  })
+  const isPopoverFocused = () => {
+    return !editorFocused && host.contains(host.ownerDocument.activeElement)
+  }
 
   useEditorFocusChangeEvent(host, (focus) => {
-    if (focus) {
-      interacting = false
-    }
+    editorFocused = focus
   })
 
   useEditorUpdateEvent(host, (view) => {
-    if (interacting) {
-      return
-    }
+    if (isPopoverFocused()) return
 
     const ref = getVirtualSelectionElement(view)
 

--- a/packages/lit/src/controllers/use-dismissable.ts
+++ b/packages/lit/src/controllers/use-dismissable.ts
@@ -5,7 +5,7 @@ import type { LitElement } from 'lit'
 import { getReferenceContextElement } from '../utils/get-reference-context-element'
 
 /**
- * @internal 
+ * @internal
  */
 export function useDismissable(
   host: LitElement,

--- a/packages/lit/src/controllers/use-dismissable.ts
+++ b/packages/lit/src/controllers/use-dismissable.ts
@@ -4,6 +4,9 @@ import type { LitElement } from 'lit'
 
 import { getReferenceContextElement } from '../utils/get-reference-context-element'
 
+/**
+ * @internal 
+ */
 export function useDismissable(
   host: LitElement,
   {

--- a/packages/lit/src/controllers/use-editor-extension.ts
+++ b/packages/lit/src/controllers/use-editor-extension.ts
@@ -4,7 +4,7 @@ import type { ReactiveControllerHost } from 'lit'
 import type { WithEditor } from '../types/with-editor'
 
 /**
- * @internal 
+ * @internal
  */
 export function useEditorExtension(
   host: WithEditor<ReactiveControllerHost>,

--- a/packages/lit/src/controllers/use-editor-extension.ts
+++ b/packages/lit/src/controllers/use-editor-extension.ts
@@ -3,6 +3,9 @@ import type { ReactiveControllerHost } from 'lit'
 
 import type { WithEditor } from '../types/with-editor'
 
+/**
+ * @internal 
+ */
 export function useEditorExtension(
   host: WithEditor<ReactiveControllerHost>,
   extension: Extension,

--- a/packages/lit/src/controllers/use-editor-focus-event.ts
+++ b/packages/lit/src/controllers/use-editor-focus-event.ts
@@ -8,6 +8,9 @@ import type { WithEditor } from '../types/with-editor'
 
 import { useEditorExtension } from './use-editor-extension'
 
+/**
+ * @internal
+ */
 export function useEditorFocusChangeEvent(
   host: WithEditor<ReactiveControllerHost>,
   handler: FocusChangeHandler,

--- a/packages/lit/src/controllers/use-editor-update-event.ts
+++ b/packages/lit/src/controllers/use-editor-update-event.ts
@@ -5,6 +5,9 @@ import type { WithEditor } from '../types/with-editor'
 
 import { useEditorExtension } from './use-editor-extension'
 
+/**
+ * @internal 
+ */
 export function useEditorUpdateEvent(
   host: WithEditor<ReactiveControllerHost>,
   handler: UpdateHandler,

--- a/packages/lit/src/controllers/use-editor-update-event.ts
+++ b/packages/lit/src/controllers/use-editor-update-event.ts
@@ -6,7 +6,7 @@ import type { WithEditor } from '../types/with-editor'
 import { useEditorExtension } from './use-editor-extension'
 
 /**
- * @internal 
+ * @internal
  */
 export function useEditorUpdateEvent(
   host: WithEditor<ReactiveControllerHost>,

--- a/packages/lit/src/controllers/use-effect.ts
+++ b/packages/lit/src/controllers/use-effect.ts
@@ -1,5 +1,8 @@
 import type { ReactiveControllerHost } from 'lit'
 
+/**
+ * @internal 
+ */
 export function useEffect<T>(
   host: ReactiveControllerHost,
   getValue: () => T,

--- a/packages/lit/src/controllers/use-effect.ts
+++ b/packages/lit/src/controllers/use-effect.ts
@@ -1,7 +1,7 @@
 import type { ReactiveControllerHost } from 'lit'
 
 /**
- * @internal 
+ * @internal
  */
 export function useEffect<T>(
   host: ReactiveControllerHost,

--- a/packages/lit/src/controllers/use-pointer-down-event.ts
+++ b/packages/lit/src/controllers/use-pointer-down-event.ts
@@ -1,5 +1,8 @@
 import type { LitElement } from 'lit'
 
+/**
+ * @internal
+ */
 export function usePointerDownEvent(
   host: LitElement,
   handler: (event: PointerEvent) => void,


### PR DESCRIPTION

https://github.com/ocavue/prosekit/assets/24715727/d382a5de-9675-4651-8b14-46deedb87008



https://github.com/ocavue/prosekit/assets/24715727/cb98eb0e-6044-4756-89ae-6a85f02135cf


