### PR TITLE
docs: tweak website border styling

### DIFF
--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -12,8 +12,12 @@ body .Layout .VPNav .VPNavBar {
   background: var(--prosekit-nav-bg) !important;
 }
 
-body .Layout .VPLocalNav {
-  border-top: none;
+body .Layout .VPNav .VPNavBar .VPNavBarTitle * {
+  border: none;
+}
+
+body .Layout .VPNav .VPNavBar .divider {
+  padding-left: 0;
 }
 
 @media (min-width: 960px) {


### PR DESCRIPTION
Before 

<img width="539" alt="image" src="https://github.com/ocavue/prosekit/assets/24715727/715e71c8-3192-434a-944f-333058da2499">


After 

<img width="554" alt="image" src="https://github.com/ocavue/prosekit/assets/24715727/aaa8c0d2-d441-4fd6-9c2c-270e2cf77508">
