### PR TITLE
fix(web): hide inline popover for node selections

### DIFF
--- a/.changeset/metal-dolphins-peel.md
+++ b/.changeset/metal-dolphins-peel.md
@@ -1,0 +1,5 @@
+---
+"@prosekit/web": patch
+---
+
+Don't show the inline popover when an inline node is selected.

--- a/.changeset/metal-dolphins-peel.md
+++ b/.changeset/metal-dolphins-peel.md
@@ -1,5 +1,6 @@
 ---
-"@prosekit/web": patch
+'prosekit': patch
+'@prosekit/web': patch
 ---
 
 Don't show the inline popover when an inline node is selected.

--- a/packages/web/src/components/inline-popover/inline-popover/virtual-selection-element.ts
+++ b/packages/web/src/components/inline-popover/inline-popover/virtual-selection-element.ts
@@ -1,5 +1,5 @@
 import type { ReferenceElement } from '@floating-ui/dom'
-import { isNodeSelection, isTextSelection } from '@prosekit/core'
+import { isTextSelection } from '@prosekit/core'
 import type { EditorView } from '@prosekit/pm/view'
 
 import { isInCodeBlock } from '../../../utils/is-in-code-block'
@@ -16,7 +16,7 @@ export function getVirtualSelectionElement(
   if (
     !selection.empty &&
     !isInCodeBlock(selection) &&
-    (isTextSelection(selection) || isNodeSelection(selection))
+    isTextSelection(selection)
   ) {
     const decoration = getInlineDecoration(view)
     if (decoration) {


### PR DESCRIPTION
before

<img width="387" alt="image" src="https://github.com/ocavue/prosekit/assets/24715727/a4dff0ef-b709-4014-b594-bbbccfd4fc80">


after

<img width="280" alt="image" src="https://github.com/ocavue/prosekit/assets/24715727/a7e5b652-f21e-48e1-97a3-4ecc8374ea51">
