### PR TITLE
fix(virtual-selection): change background color to gray

### DIFF
--- a/.changeset/green-kiwis-kiss.md
+++ b/.changeset/green-kiwis-kiss.md
@@ -1,4 +1,5 @@
 ---
+'prosekit': patch
 '@prosekit/extensions': patch
 ---
 

--- a/.changeset/green-kiwis-kiss.md
+++ b/.changeset/green-kiwis-kiss.md
@@ -1,0 +1,5 @@
+---
+'@prosekit/extensions': patch
+---
+
+Set the default background color of the `.prosekit-virtual-selection` element to a gray color.

--- a/packages/extensions/src/virtual-selection/style.css
+++ b/packages/extensions/src/virtual-selection/style.css
@@ -1,5 +1,5 @@
 .prosekit-virtual-selection {
   background-color: #8888884d;
-  box-shadow: 0 0 0 3px #8888884d;
+  box-shadow: 0 0 0 2px #8888884d;
   border-radius: 2px;
 }

--- a/packages/extensions/src/virtual-selection/style.css
+++ b/packages/extensions/src/virtual-selection/style.css
@@ -1,5 +1,5 @@
 .prosekit-virtual-selection {
-  background-color: Highlight;
-  box-shadow: 0 0 0 3px Highlight;
+  background-color: #8888884d;
+  box-shadow: 0 0 0 3px #8888884d;
   border-radius: 2px;
 }


### PR DESCRIPTION
Chrome v125 set `Highlight` as a dark blue color, which is not suitable for us.

**Before**

<img width="398" alt="image" src="https://github.com/ocavue/prosekit/assets/24715727/d0b6b33b-0fe0-483f-82c6-53d123d60302">


**After**

<img width="361" alt="image" src="https://github.com/ocavue/prosekit/assets/24715727/f63013bf-d101-47b6-a76c-d826dfbf9303">
